### PR TITLE
DRP-4: Updated the  node version of the lando.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -25,7 +25,7 @@ services:
     hogfrom:
       - appserver
   node:
-    type: node:14
+    type: node:18
     build_as_root:
       - npm install -g gulp-cli gulp
   adminer:
@@ -46,9 +46,9 @@ tooling:
     env:
       DRUSH_OPTIONS_URI: "https://drupal-starter-project.lndo.site"
   node:
-    service: appserver
+    service: node
   npm:
-    service: appserver
+    service: node
   xdebug-on:
     service: appserver
     description: Enable xdebug for nginx.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project template provides a starter kit for managing your site dependencies
 ## Requirements
 
 - Composer - You can download composer from [here](https://getcomposer.org/download/)
-- Lando - You can follow the instructions for downloading lando from [here](https://docs.lando.dev/getting-started/installation.html).
+- Lando (v3.11) - You can follow the instructions for downloading lando from [here](https://docs.lando.dev/getting-started/installation.html).
 
 ## Usage
 


### PR DESCRIPTION
- Fixed lando `node` & `npm` tools to use proper service.
- Updated the README file to mention the basic lando version required to run node 18.